### PR TITLE
Changed reference type on verify method to string

### DIFF
--- a/src/transaction/transaction.ts
+++ b/src/transaction/transaction.ts
@@ -45,7 +45,7 @@ export class Transaction {
     );
   }
   async verify(
-    reference: number,
+    reference: string,
   ): Promise<GetTransactionResponse | BadRequest> {
     return await this.http.get(`/transaction/verify/${reference}`);
   }


### PR DESCRIPTION
I guess it's an oversight because on the initialize method the reference type is a string 